### PR TITLE
Add RoR online courses catalog (Classpert)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [GoRails](https://gorails.com)
 - [Drifting Ruby](https://www.driftingruby.com/)
 - [Ruby on Windows Guides](http://rubyonwindowsguides.github.io)
+- [Ruby on Rails Online Courses](https://classpert.com/ruby-on-rails)
 
 [Back to top](#table-of-contents)
 


### PR DESCRIPTION
This commit adds Classpert to the “External Resources” section, with a comprehensive selection of ~ 70 Ruby on Rails courses (free and paid) from top e-learning providers like Udemy, Coursera, Pluralsight,Treehouse, and Skillshare.